### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   linux-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,9 @@
 name: Labeler
 on: [pull_request]
 
+permissions:
+  pull-requests: write
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - '*' # Push events to matching v*, i.e. v1.0, v20.15.10
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.